### PR TITLE
Fix: 'X509Certificate is immutable on this platform..' on dotNet Core

### DIFF
--- a/Saml/Saml.cs
+++ b/Saml/Saml.cs
@@ -75,8 +75,7 @@ namespace Saml
         {
             try
             {
-                cert = new X509Certificate2();
-                cert.Import(certificate);
+                cert = new X509Certificate2(certificate);
             } catch (Exception ex)
             {
                 throw new LoadCertificateException("Failed to load certificate", ex);


### PR DESCRIPTION
LoadCertificate(byte[]) to instantiate X509Certificate2 with byte array. Addresses 'X509Certificate is immutable on this platform. Use the equivalent constructor instead.' on dotNet Core
Related to [https://github.com/jitbit/AspNetSaml/issues/9](https://github.com/jitbit/AspNetSaml/issues/9)