### PR TITLE
Untracked: Check for normal SAML groups identifier as well as MS

### DIFF
--- a/Saml/Saml.cs
+++ b/Saml/Saml.cs
@@ -314,7 +314,7 @@ namespace Saml
 
 		private string AttributeByNameXPath(string name) => $"/samlp:Response/saml:Assertion[1]/saml:AttributeStatement/saml:Attribute[@Name='{name}']/saml:AttributeValue";
 
-		private string GetCustomAttribute(string attr)
+		public string GetCustomAttribute(string attr)
 		{
 			XmlNode node = _xmlDoc.SelectSingleNode(AttributeByNameXPath(attr), _xmlNameSpaceManager);
 			return node == null ? null : node.InnerText;

--- a/Saml/Saml.cs
+++ b/Saml/Saml.cs
@@ -104,7 +104,7 @@ namespace Saml
 		private const string NORMAL_ATTRIBUTE_NAME_PREFIX = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/";
 		private const string GROUPS_MS_NAME_PREFIX = "http://schemas.microsoft.com/ws/2008/06/identity/claims/";
 
-        protected XmlDocument _xmlDoc;
+		protected XmlDocument _xmlDoc;
 		protected readonly X509Certificate2 _certificate;
 		protected XmlNamespaceManager _xmlNameSpaceManager; //we need this one to run our XPath queries on the SAML XML
 

--- a/Saml/Saml.nuspec
+++ b/Saml/Saml.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Displayr.AspNetSaml</id>
     <title>Saml library for Service Providers written in .NET</title>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
     <description>This package allows your web application or SAML service provider to integrate with a third party SAML Identity Provider (e.g. Microsoft Azure AD). Displayr.AspNetSaml is a fork of https://www.nuget.org/packages/AspNetSaml that includes some changes that the https://www.displayr.com engineering team required for their SAML integration.</description>
     <summary>Integrate your application with a SAML Identity Provider.</summary>
     <authors>displayr.com_martincapodici</authors>

--- a/saml.Test/saml.Test/Saml.Test.csproj
+++ b/saml.Test/saml.Test/Saml.Test.csproj
@@ -141,6 +141,9 @@
       <Name>Saml</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="valid_response_base_groups.xml" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/saml.Test/saml.Test/TestResponseClassSaml.cs
+++ b/saml.Test/saml.Test/TestResponseClassSaml.cs
@@ -49,6 +49,26 @@ namespace Saml.Test
             Assert.AreEqual("87654321-testing4-testing3", groups[1]);
         }
 
+        // <summary>
+        /// This test method ensures that the groups getter works with the non MS groups name to.
+        /// </summary>
+        [TestMethod()]
+        public void TestGroupsGetter()
+        {
+            // Certificate here is unimportant to actual response as we wont validate, just needs to be a valid cert.
+            Response response = new Response(Constants.VALID_CERTIFICATE);
+
+            string xml_contents = GetResourceContents(Constants.VALID_XML_WITH_BASE_GROUPS_RESPONSE_RESOURCE);
+
+            response.LoadXml(xml_contents);
+
+            List<string> groups = response.GetGroups();
+
+            Assert.AreEqual(2, groups.Count);
+            Assert.AreEqual("12345678-testing1-testing2", groups[0]);
+            Assert.AreEqual("87654321-testing4-testing3", groups[1]);
+        }
+
         /// <summary>This test method loads an empty XML SAML response and a legitimate certificate
         /// into the 'Response' class of the SAML library. The test ensures that the appropriate 
         /// exception is thrown.</summary>

--- a/saml.Test/saml.Test/constants.cs
+++ b/saml.Test/saml.Test/constants.cs
@@ -46,6 +46,7 @@ unr4TOQQAYtnBQT4DCGs
 -----END CERTIFICATE-----";
 
         public const string VALID_XML_RESPONSE_RESOURCE     = "Saml.Test.valid_response.xml";
+        public const string VALID_XML_WITH_BASE_GROUPS_RESPONSE_RESOURCE = "Saml.Test.valid_response_base_groups.xml";
         public const string INVALID_XML_RESPONSE_RESOURCE   = "Saml.Test.invalid_response.xml";
         public const string EMPTY_XML_RESPONSE_RESOURCE     = "Saml.Test.empty_response.xml";
         public const string MICROSOFT_XML_RESPONSE_RESOURCE = "Saml.Test.microsoft_response_valid.xml";

--- a/saml.Test/saml.Test/valid_response_base_groups.xml
+++ b/saml.Test/saml.Test/valid_response_base_groups.xml
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="pfxacd78e6d-2a99-c634-d78e-6e349b4c76d8" Version="2.0" IssueInstant="2018-12-05T05:45:42.554Z" Destination="https://localhost:44376/Home/WelcomeUser" InResponseTo="_3d89261c-e59d-4b80-b65f-74a921075798">
+	<Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">https://sts.windows.net/86c4efd3-7f59-4e51-8f64-6d7848dfcaef/</Issuer>
+	<samlp:Status>
+		<samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+	</samlp:Status>
+	<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_a46864cb-7e92-4043-bbbf-67fe24ca4285" IssueInstant="2018-12-05T05:45:42.554Z" Version="2.0">
+		<Issuer>https://sts.windows.net/86c4efd3-7f59-4e51-8f64-6d7848dfcaef/</Issuer>
+		<Subject>
+			<NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">george@george.com</NameID>
+			<SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+				<SubjectConfirmationData InResponseTo="_3d89261c-e59d-4b80-b65f-74a921075798" NotOnOrAfter="2018-12-05T05:50:42.554Z" Recipient="https://localhost:44376/Home/WelcomeUser"/>
+			</SubjectConfirmation>
+		</Subject>
+		<Conditions NotBefore="2018-12-05T05:40:42.554Z" NotOnOrAfter="2018-12-05T06:40:42.554Z">
+			<AudienceRestriction>
+				<Audience>spn:15eedc3e-ead5-47c8-8424-a98027d91da7</Audience>
+			</AudienceRestriction>
+		</Conditions>
+		<AttributeStatement>
+			<Attribute Name="http://schemas.microsoft.com/identity/claims/tenantid">
+				<AttributeValue>86c4efd3-7f59-4e51-8f64-6d7848dfcaef</AttributeValue>
+			</Attribute>
+			<Attribute Name="http://schemas.microsoft.com/identity/claims/objectidentifier">
+				<AttributeValue>d0da4e9e-3609-4f53-aaeb-2f3f58478ce2</AttributeValue>
+			</Attribute>
+			<Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/displayname">
+				<AttributeValue>George Willy</AttributeValue>
+			</Attribute>
+			<Attribute Name="groups">
+				<AttributeValue>12345678-testing1-testing2</AttributeValue>
+				<AttributeValue>87654321-testing4-testing3</AttributeValue>
+			</Attribute>
+			<Attribute Name="http://schemas.microsoft.com/identity/claims/identityprovider">
+				<AttributeValue>https://sts.windows.net/97fb2e3d-d978-44e1-bb74-0aa0109189b5/</AttributeValue>
+			</Attribute>
+			<Attribute Name="http://schemas.microsoft.com/claims/authnmethodsreferences">
+				<AttributeValue>http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/password</AttributeValue>
+			</Attribute>
+			<Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/wids">
+				<AttributeValue>62e90394-69f5-4237-9190-012177145e10</AttributeValue>
+			</Attribute>
+			<Attribute Name="first_name">
+				<AttributeValue>George</AttributeValue>
+			</Attribute>
+			<Attribute Name="last_name">
+				<AttributeValue>Willy</AttributeValue>
+			</Attribute>
+			<Attribute Name="User.email">
+				<AttributeValue>george@george.com</AttributeValue>
+			</Attribute>
+			<Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name">
+				<AttributeValue>george@george.com</AttributeValue>
+			</Attribute>
+			<Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/department">
+				<AttributeValue>Car repairs</AttributeValue>
+			</Attribute>
+			<Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/homephone">
+				<AttributeValue>04567843543</AttributeValue>
+			</Attribute>
+			<Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/companyname">
+				<AttributeValue>Displayr</AttributeValue>
+			</Attribute>
+		</AttributeStatement>
+		<AuthnStatement AuthnInstant="2018-12-05T05:45:42.429Z" SessionIndex="_a46864cb-7e92-4043-bbbf-67fe24ca4285">
+			<AuthnContext>
+				<AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</AuthnContextClassRef>
+			</AuthnContext>
+		</AuthnStatement>
+	</Assertion>
+</samlp:Response>


### PR DESCRIPTION
We got this as feedback from a user setting up SSO once and so I added the same sort of setup we have elsewhere, where we try the url prefixed version and non prefixed version for groups.